### PR TITLE
Null check when restoring saved fragment tags.

### DIFF
--- a/app/src/main/java/com/example/fragmentstatepagerissueexample/app/FixedFragmentStatePagerAdapter.java
+++ b/app/src/main/java/com/example/fragmentstatepagerissueexample/app/FixedFragmentStatePagerAdapter.java
@@ -218,7 +218,13 @@ public abstract class FixedFragmentStatePagerAdapter extends PagerAdapter {
             Parcelable[] fss = bundle.getParcelableArray("states");
             mSavedState.clear();
             mFragments.clear();
-            mSavedFragmentTags = bundle.getStringArrayList("tags");
+
+            ArrayList<String> tags = bundle.getStringArrayList("tags");
+            if (tags != null) {
+                mSavedFragmentTags = tags;
+            } else {
+                mSavedFragmentTags.clear();
+            }
             if (fss != null) {
                 for (int i=0; i<fss.length; i++) {
                     mSavedState.add((Fragment.SavedState)fss[i]);


### PR DESCRIPTION
Fixes NPE in destroyItem after restoring state saved where mSavedState.size() was 0.

Fragment tags (and fragment saved state) are only saved in saveState if mSavedState contains items. If the user has not moved through any pages, then state is saved and restored, a null pointer exception will occur in destroyItem when attempting to store the fragment tag, as mSavedFragmentTags will be null.
